### PR TITLE
Add terminal renderer with live status table

### DIFF
--- a/dag/__init__.py
+++ b/dag/__init__.py
@@ -3,6 +3,15 @@
 from dag.cell import Cell, cell
 from dag.engine import PipelineEngine
 from dag.graph import CycleError, DAGGraph
+from dag.renderer import PipelineRenderer
 from dag.store import CellStore
 
-__all__ = ["Cell", "CellStore", "CycleError", "DAGGraph", "PipelineEngine", "cell"]
+__all__ = [
+    "Cell",
+    "CellStore",
+    "CycleError",
+    "DAGGraph",
+    "PipelineEngine",
+    "PipelineRenderer",
+    "cell",
+]

--- a/dag/engine.py
+++ b/dag/engine.py
@@ -15,23 +15,41 @@ class PipelineEngine:
     """Execute cells in topological order, with reactive invalidation."""
 
     def __init__(
-        self, cells: list[Cell], *, store: CellStore | None = None
+        self,
+        cells: list[Cell],
+        *,
+        store: CellStore | None = None,
+        on_status_change: Callable[[Cell, str], None] | None = None,
     ) -> None:
         self._cells = cells
         self._graph = DAGGraph()
         self._graph.build(cells)
         self._graph.validate()
         self._store = store
+        self._on_status_change = on_status_change
+        self._cached: set[str] = set()
+
+    @property
+    def cached_cells(self) -> set[str]:
+        """Names of cells that were loaded from cache in the last run."""
+        return self._cached
+
+    def _set_status(self, cell: Cell, status: str) -> None:
+        cell.status = status
+        if self._on_status_change:
+            self._on_status_change(cell, status)
 
     def run_all(self) -> None:
         """Execute all cells in topological order, loading cached outputs when fresh."""
+        self._cached = set()
         for c in self._cells:
-            c.status = "pending"
+            self._set_status(c, "pending")
         must_run: set[str] = set()
         for c in self._graph.topological_order():
             if c.name not in must_run and self._store and self._store.is_fresh(c):
                 c.output = self._store.load(c)
-                c.status = "done"
+                self._cached.add(c.name)
+                self._set_status(c, "done")
             else:
                 self._execute_cell(c)
                 # Descendants must re-execute since this cell's output changed
@@ -40,9 +58,9 @@ class PipelineEngine:
 
     def invalidate(self, cell: Cell) -> None:
         """Mark cell and all its descendants as stale."""
-        cell.status = "stale"
+        self._set_status(cell, "stale")
         for desc in self._graph.descendants(cell):
-            desc.status = "stale"
+            self._set_status(desc, "stale")
 
     def run_stale(self) -> None:
         """Re-execute only stale cells in topological order."""
@@ -58,21 +76,21 @@ class PipelineEngine:
 
     def _execute_cell(self, cell: Cell) -> None:
         """Execute a single cell, collecting dep outputs as positional args."""
-        cell.status = "running"
+        self._set_status(cell, "running")
         # Collect outputs from dependencies in depends_on order
         dep_outputs = [dep.output for dep in cell.depends_on]
         start = time.monotonic()
         try:
             cell.output = cell.func(*dep_outputs)
-            cell.status = "done"
             if self._store:
                 self._store.save(cell)
+            self._set_status(cell, "done")
         except Exception as exc:
-            cell.status = "error"
             cell.error = exc
+            self._set_status(cell, "error")
             # Mark all descendants as error too
             for desc in self._graph.descendants(cell):
-                desc.status = "error"
+                self._set_status(desc, "error")
             return
         finally:
             cell.duration_seconds = time.monotonic() - start

--- a/dag/renderer.py
+++ b/dag/renderer.py
@@ -1,0 +1,102 @@
+"""PipelineRenderer — live terminal status table using Rich."""
+
+from __future__ import annotations
+
+import time
+
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+
+from dag.cell import Cell
+from dag.engine import PipelineEngine
+from dag.store import CellStore
+
+_STATUS_DISPLAY = {
+    "pending": ("[dim]pending[/dim]", ""),
+    "running": ("[blue bold]running[/blue bold]", "..."),
+    "done": ("[green]done[/green]", ""),
+    "stale": ("[yellow]stale[/yellow]", ""),
+    "error": ("[red bold]error[/red bold]", ""),
+}
+
+
+class PipelineRenderer:
+    """Render pipeline execution as a live-updating Rich table."""
+
+    def __init__(self, name: str = "pipeline") -> None:
+        self._name = name
+        self._console = Console()
+        self._cells: list[Cell] = []
+        self._engine: PipelineEngine | None = None
+        self._live: Live | None = None
+        self._start_time: float = 0.0
+
+    def _build_table(self) -> Table:
+        table = Table(title=f"Pipeline: {self._name}")
+        table.add_column("Cell", style="bold")
+        table.add_column("Status")
+        table.add_column("Duration", justify="right")
+        table.add_column("Cached", justify="center")
+
+        for c in self._cells:
+            style_text, default_dur = _STATUS_DISPLAY.get(
+                c.status, (c.status, "")
+            )
+            duration = (
+                f"{c.duration_seconds:.3f}s"
+                if c.duration_seconds is not None
+                else default_dur
+            )
+            cached = ""
+            if self._engine and c.status == "done":
+                cached = (
+                    "[dim]yes[/dim]"
+                    if c.name in self._engine.cached_cells
+                    else "no (ran)"
+                )
+            table.add_row(c.name, style_text, duration, cached)
+
+        return table
+
+    def _on_status_change(self, cell: Cell, status: str) -> None:
+        if self._live:
+            self._live.update(self._build_table())
+
+    def run(
+        self,
+        cells: list[Cell],
+        *,
+        store: CellStore | None = None,
+    ) -> PipelineEngine:
+        """Run the pipeline with a live-updating status table."""
+        self._cells = cells
+        self._engine = PipelineEngine(
+            cells,
+            store=store,
+            on_status_change=self._on_status_change,
+        )
+        self._start_time = time.monotonic()
+
+        with Live(self._build_table(), console=self._console, refresh_per_second=10) as live:
+            self._live = live
+            self._engine.run_all()
+            # Final update
+            live.update(self._build_table())
+            self._live = None
+
+        # Summary line
+        elapsed = time.monotonic() - self._start_time
+        n_cached = len(self._engine.cached_cells)
+        n_ran = len(cells) - n_cached
+        self._console.print(
+            f"\n[bold]{n_ran} cells ran, {n_cached} cached, "
+            f"total {elapsed:.3f}s[/bold]"
+        )
+
+        return self._engine
+
+    def status(self, cells: list[Cell]) -> None:
+        """Print a static status table (no execution)."""
+        self._cells = cells
+        self._console.print(self._build_table())

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,83 @@
+"""Tests for PipelineRenderer and engine status change callbacks."""
+
+from dag.cell import cell
+from dag.engine import PipelineEngine
+from dag.renderer import PipelineRenderer
+
+
+class TestStatusChangeCallback:
+    def test_callback_fires_on_status_changes(self) -> None:
+        @cell
+        def a():
+            return 1
+
+        @cell(depends_on=[a])
+        def b(a):
+            return a + 1
+
+        changes: list[tuple[str, str]] = []
+
+        def on_change(c, status):
+            changes.append((c.name, status))
+
+        engine = PipelineEngine([a, b], on_status_change=on_change)
+        engine.run_all()
+
+        # Should see: pending, pending, running, done, running, done
+        assert ("a", "pending") in changes
+        assert ("b", "pending") in changes
+        assert ("a", "running") in changes
+        assert ("a", "done") in changes
+        assert ("b", "running") in changes
+        assert ("b", "done") in changes
+
+    def test_cached_cells_tracked(self, tmp_path) -> None:
+        from dag.store import CellStore
+
+        @cell
+        def a():
+            return 42
+
+        store = CellStore(tmp_path / "cache")
+        engine = PipelineEngine([a], store=store)
+        engine.run_all()
+        assert "a" not in engine.cached_cells
+
+        # Reset and run again — should be cached
+        a.output = None
+        a.status = "pending"
+        a.last_run = None
+
+        engine2 = PipelineEngine([a], store=store)
+        engine2.run_all()
+        assert "a" in engine2.cached_cells
+
+
+class TestRendererTableBuild:
+    def test_build_table_has_correct_columns(self) -> None:
+        @cell
+        def a():
+            return 1
+
+        renderer = PipelineRenderer(name="test")
+        renderer._cells = [a]
+        renderer._engine = PipelineEngine([a])
+        table = renderer._build_table()
+
+        assert table.title == "Pipeline: test"
+        assert len(table.columns) == 4
+        col_names = [c.header for c in table.columns]
+        assert "Cell" in str(col_names[0])
+        assert "Status" in str(col_names[1])
+
+    def test_status_method_prints_table(self, capsys) -> None:
+        @cell
+        def a():
+            return 1
+
+        a.status = "done"
+        a.duration_seconds = 0.5
+
+        renderer = PipelineRenderer(name="test")
+        renderer.status([a])
+        # Just verify it doesn't crash — Rich output goes to console


### PR DESCRIPTION
## Summary
- `PipelineRenderer` class using `rich.live` + `rich.table` for real-time status display
- Color-coded status: green=done, blue=running, grey=pending, yellow=stale, red=error
- Cached indicator column showing "yes" (dim) or "no (ran)" for each cell
- Summary line: N cells ran, M cached, total time
- Engine gains `on_status_change` callback and `cached_cells` tracking
- `status()` method for static table display (no execution)

## Test plan
- [x] Status change callback fires for all transitions (pending→running→done)
- [x] `cached_cells` correctly tracks which cells loaded from cache
- [x] Table builds with correct columns and title
- [x] `status()` renders without errors
- [x] All 36 tests pass (4 new + 32 existing)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)