### PR TITLE
Add CLI: dag run, status, invalidate, graph

### DIFF
--- a/dag/cli.py
+++ b/dag/cli.py
@@ -1,12 +1,118 @@
 """CLI entrypoint for the reactive DAG pipeline."""
 
+from __future__ import annotations
+
+from pathlib import Path
+
 import click
+
+from dag.engine import PipelineEngine
+from dag.loader import load_pipeline
+from dag.renderer import PipelineRenderer
+from dag.store import CellStore
+
+
+def _store_for(pipeline_path: str) -> CellStore:
+    """Create a CellStore scoped to the pipeline file name."""
+    name = Path(pipeline_path).stem
+    return CellStore(Path.home() / ".dag" / "cache" / name)
 
 
 @click.group()
 @click.version_option()
 def main() -> None:
     """Reactive DAG Pipeline — build and run reactive computation graphs."""
+
+
+@main.command()
+@click.argument("pipeline", type=click.Path(exists=True))
+@click.option("--cell", "cell_name", default=None, help="Run only from this cell downward.")
+def run(pipeline: str, cell_name: str | None) -> None:
+    """Run all cells in a pipeline file."""
+    cells = load_pipeline(pipeline)
+    store = _store_for(pipeline)
+    name = Path(pipeline).stem
+    renderer = PipelineRenderer(name=name)
+
+    if cell_name is not None:
+        # Run the full pipeline first (loading cache), then invalidate+run from cell
+        engine = PipelineEngine(cells, store=store)
+        engine.run_all()
+        target = next((c for c in cells if c.name == cell_name), None)
+        if target is None:
+            raise click.ClickException(f"Cell '{cell_name}' not found in pipeline")
+        engine.invalidate(target)
+        engine.run_stale()
+        renderer.status(cells)
+    else:
+        renderer.run(cells, store=store)
+
+
+@main.command()
+@click.argument("pipeline", type=click.Path(exists=True))
+def status(pipeline: str) -> None:
+    """Show cell status table without executing."""
+    cells = load_pipeline(pipeline)
+    store = _store_for(pipeline)
+    name = Path(pipeline).stem
+
+    # Load cached state
+    for c in cells:
+        if store.is_fresh(c):
+            c.output = store.load(c)
+            c.status = "done"
+
+    renderer = PipelineRenderer(name=name)
+    renderer.status(cells)
+
+
+@main.command()
+@click.argument("pipeline", type=click.Path(exists=True))
+@click.option("--cell", "cell_name", default=None, help="Invalidate from this cell downward.")
+@click.option("--all", "invalidate_all", is_flag=True, help="Clear all cache.")
+def invalidate(pipeline: str, cell_name: str | None, invalidate_all: bool) -> None:
+    """Mark cells as stale so they re-execute on next run."""
+    cells = load_pipeline(pipeline)
+    store = _store_for(pipeline)
+
+    if invalidate_all:
+        for c in cells:
+            store.invalidate(c)
+        click.echo(f"Cleared cache for all {len(cells)} cells.")
+        return
+
+    if cell_name is None:
+        raise click.ClickException("Specify --cell NAME or --all")
+
+    target = next((c for c in cells if c.name == cell_name), None)
+    if target is None:
+        raise click.ClickException(f"Cell '{cell_name}' not found in pipeline")
+
+    engine = PipelineEngine(cells, store=store)
+    store.invalidate(target)
+    descendants = engine._graph.descendants(target)
+    for desc in descendants:
+        store.invalidate(desc)
+
+    click.echo(f"Invalidated {target.name} and {len(descendants)} descendant(s).")
+
+
+@main.command()
+@click.argument("pipeline", type=click.Path(exists=True))
+def graph(pipeline: str) -> None:
+    """Print the dependency graph as ASCII."""
+    from networkx.readwrite.text import generate_network_text
+
+    from dag.graph import DAGGraph
+
+    cells = load_pipeline(pipeline)
+    dag = DAGGraph()
+    dag.build(cells)
+
+    click.echo(f"Pipeline: {Path(pipeline).stem}")
+    click.echo()
+    for line in generate_network_text(dag._graph):
+        click.echo(line)
 
 
 if __name__ == "__main__":

--- a/dag/loader.py
+++ b/dag/loader.py
@@ -1,0 +1,39 @@
+"""Load a pipeline definition from a Python file."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from dag.cell import Cell
+
+
+def load_pipeline(path: str) -> list[Cell]:
+    """Import a Python file and return its Cell objects.
+
+    The file should either define a ``CELLS`` list or the loader
+    will collect all module-level ``Cell`` instances.
+    """
+    filepath = Path(path).resolve()
+    if not filepath.exists():
+        raise FileNotFoundError(f"Pipeline file not found: {filepath}")
+
+    spec = importlib.util.spec_from_file_location("_pipeline", filepath)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {filepath}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["_pipeline"] = module
+    spec.loader.exec_module(module)
+
+    # Prefer explicit CELLS list
+    if hasattr(module, "CELLS"):
+        return list(module.CELLS)
+
+    # Otherwise collect all Cell instances from module namespace
+    cells = [v for v in vars(module).values() if isinstance(v, Cell)]
+    if not cells:
+        raise ValueError(f"No Cell objects found in {filepath}")
+
+    return cells

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,0 +1,21 @@
+"""Simple example pipeline for testing CLI commands."""
+
+from dag.cell import cell
+
+@cell
+def raw_data():
+    return [1, 2, 3, 4, 5]
+
+@cell(depends_on=[raw_data])
+def filtered(raw_data):
+    return [x for x in raw_data if x > 2]
+
+@cell(depends_on=[filtered])
+def summary(filtered):
+    return f"{len(filtered)} items match"
+
+@cell(depends_on=[raw_data, filtered])
+def comparison(raw_data, filtered):
+    return f"{len(filtered)} / {len(raw_data)} items"
+
+CELLS = [raw_data, filtered, summary, comparison]


### PR DESCRIPTION
## Summary
- `dag run <file>`: execute pipeline with live Rich status table, `--cell` for partial runs
- `dag status <file>`: show cached cell states without executing
- `dag invalidate <file>`: clear cache with `--cell NAME` or `--all`
- `dag graph <file>`: print ASCII dependency tree
- Pipeline loader: imports .py files, discovers `CELLS` list or auto-collects Cell objects
- Example pipeline in `examples/simple.py`

## Test plan
- [x] `dag run examples/simple.py` — all 4 cells execute, status=done
- [x] `dag run examples/simple.py` (second run) — raw_data cached, others ran
- [x] `dag status examples/simple.py` — shows cached state
- [x] `dag invalidate examples/simple.py --cell filtered` — invalidates 1 cell + 2 descendants
- [x] `dag graph examples/simple.py` — prints ASCII dependency tree
- [x] All 36 tests pass

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)