### PR TITLE
Add dag watch: live reactive re-execution on file save

### DIFF
--- a/dag/cli.py
+++ b/dag/cli.py
@@ -99,6 +99,17 @@ def invalidate(pipeline: str, cell_name: str | None, invalidate_all: bool) -> No
 
 @main.command()
 @click.argument("pipeline", type=click.Path(exists=True))
+@click.option("--interval", default=0.5, help="Poll interval in seconds.", show_default=True)
+def watch(pipeline: str, interval: float) -> None:
+    """Watch a pipeline file and re-execute reactively on save."""
+    from dag.watcher import PipelineWatcher
+
+    watcher = PipelineWatcher(pipeline, poll_interval=interval)
+    watcher.watch()
+
+
+@main.command()
+@click.argument("pipeline", type=click.Path(exists=True))
 def graph(pipeline: str) -> None:
     """Print the dependency graph as ASCII."""
     from networkx.readwrite.text import generate_network_text

--- a/dag/watcher.py
+++ b/dag/watcher.py
@@ -1,0 +1,199 @@
+"""Pipeline file watcher — live reactive re-execution on save."""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+
+from dag.cell import Cell
+from dag.engine import PipelineEngine
+from dag.loader import load_pipeline
+from dag.store import CellStore, _bytecode_hash
+
+
+def _collect_hashes(cells: list[Cell]) -> dict[str, str]:
+    """Snapshot bytecode hashes for all cells."""
+    return {c.name: _bytecode_hash(c) for c in cells}
+
+
+def _diff_hashes(
+    old: dict[str, str], new: dict[str, str]
+) -> list[str]:
+    """Return names of cells whose bytecode changed."""
+    changed = []
+    for name, new_hash in new.items():
+        if old.get(name) != new_hash:
+            changed.append(name)
+    return changed
+
+
+_STATUS_DISPLAY = {
+    "pending": ("[dim]pending[/dim]", ""),
+    "running": ("[blue bold]running[/blue bold]", "..."),
+    "done": ("[green]done[/green]", ""),
+    "stale": ("[yellow]stale[/yellow]", ""),
+    "error": ("[red bold]error[/red bold]", ""),
+}
+
+
+class PipelineWatcher:
+    """Watch a pipeline file and reactively re-execute on changes."""
+
+    def __init__(
+        self,
+        pipeline_path: str,
+        *,
+        poll_interval: float = 0.5,
+    ) -> None:
+        self._path = Path(pipeline_path).resolve()
+        self._name = self._path.stem
+        self._poll_interval = poll_interval
+        self._console = Console()
+        self._store = CellStore(Path.home() / ".dag" / "cache" / self._name)
+        self._cells: list[Cell] = []
+        self._engine: PipelineEngine | None = None
+        self._hashes: dict[str, str] = {}
+        self._live: Live | None = None
+        self._run_count = 0
+        self._last_message = ""
+
+    def _build_table(self) -> Table:
+        title = f"Pipeline: {self._name}  [dim](watching — Ctrl+C to stop)[/dim]"
+        table = Table(title=title)
+        table.add_column("Cell", style="bold")
+        table.add_column("Status")
+        table.add_column("Duration", justify="right")
+        table.add_column("Cached", justify="center")
+
+        for c in self._cells:
+            style_text, default_dur = _STATUS_DISPLAY.get(
+                c.status, (c.status, "")
+            )
+            duration = (
+                f"{c.duration_seconds:.3f}s"
+                if c.duration_seconds is not None
+                else default_dur
+            )
+            cached = ""
+            if self._engine and c.status == "done":
+                cached = (
+                    "[dim]yes[/dim]"
+                    if c.name in self._engine.cached_cells
+                    else "no (ran)"
+                )
+            table.add_row(c.name, style_text, duration, cached)
+
+        if self._last_message:
+            table.caption = self._last_message
+
+        return table
+
+    def _on_status_change(self, cell: Cell, status: str) -> None:
+        if self._live:
+            self._live.update(self._build_table())
+
+    def _run_pipeline(self, changed_cells: list[str] | None = None) -> None:
+        """Execute the pipeline, optionally with surgical invalidation."""
+        self._engine = PipelineEngine(
+            self._cells,
+            store=self._store,
+            on_status_change=self._on_status_change,
+        )
+        start = time.monotonic()
+
+        if changed_cells:
+            # First load everything from cache
+            self._engine.run_all()
+            # Then surgically invalidate changed cells + descendants
+            for name in changed_cells:
+                target = next((c for c in self._cells if c.name == name), None)
+                if target:
+                    self._store.invalidate(target)
+                    self._engine.invalidate(target)
+                    for desc in self._engine._graph.descendants(target):
+                        self._store.invalidate(desc)
+            self._engine.run_stale()
+        else:
+            self._engine.run_all()
+
+        elapsed = time.monotonic() - start
+        n_cached = len(self._engine.cached_cells)
+        n_ran = len(self._cells) - n_cached
+
+        if changed_cells:
+            changed_str = ", ".join(changed_cells)
+            self._last_message = (
+                f"[bold]Changed: {changed_str} — "
+                f"{n_ran} re-ran, {n_cached} cached, {elapsed:.3f}s[/bold]"
+            )
+        else:
+            self._last_message = (
+                f"[bold]Initial run — {n_ran} ran, {n_cached} cached, "
+                f"{elapsed:.3f}s[/bold]"
+            )
+
+        self._run_count += 1
+
+    def _reload_and_diff(self) -> list[str] | None:
+        """Re-import the pipeline and return names of changed cells."""
+        try:
+            new_cells = load_pipeline(str(self._path))
+        except Exception as exc:
+            self._last_message = f"[red bold]Reload error: {exc}[/red bold]"
+            return None
+
+        new_hashes = _collect_hashes(new_cells)
+        changed = _diff_hashes(self._hashes, new_hashes)
+
+        # Update state
+        self._cells = new_cells
+        self._hashes = new_hashes
+
+        return changed if changed else None
+
+    def watch(self) -> None:
+        """Main watch loop — run initial pipeline then poll for changes."""
+        self._console.print(
+            f"[bold]Watching[/bold] {self._path} "
+            f"[dim](poll every {self._poll_interval}s, Ctrl+C to stop)[/dim]\n"
+        )
+
+        # Initial run
+        self._cells = load_pipeline(str(self._path))
+        self._hashes = _collect_hashes(self._cells)
+
+        with Live(
+            self._build_table(),
+            console=self._console,
+            refresh_per_second=10,
+        ) as live:
+            self._live = live
+
+            self._run_pipeline()
+            live.update(self._build_table())
+
+            last_mtime = os.stat(self._path).st_mtime
+
+            try:
+                while True:
+                    time.sleep(self._poll_interval)
+                    current_mtime = os.stat(self._path).st_mtime
+
+                    if current_mtime != last_mtime:
+                        last_mtime = current_mtime
+                        changed = self._reload_and_diff()
+
+                        if changed is not None:
+                            self._run_pipeline(changed_cells=changed)
+
+                        live.update(self._build_table())
+
+            except KeyboardInterrupt:
+                self._live = None
+
+        self._console.print("\n[dim]Watch stopped.[/dim]")

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,187 @@
+"""Tests for watcher: bytecode diffing and surgical invalidation logic."""
+
+import textwrap
+from pathlib import Path
+
+from dag.cell import Cell, cell
+from dag.store import _bytecode_hash
+from dag.watcher import PipelineWatcher, _collect_hashes, _diff_hashes
+
+
+class TestBytecodeDiffing:
+    def test_identical_hashes_no_changes(self) -> None:
+        @cell
+        def a():
+            return 1
+
+        @cell(depends_on=[a])
+        def b(a):
+            return a + 1
+
+        hashes = _collect_hashes([a, b])
+        changed = _diff_hashes(hashes, hashes)
+        assert changed == []
+
+    def test_changed_function_detected(self) -> None:
+        @cell
+        def a():
+            return 1
+
+        old_hashes = _collect_hashes([a])
+
+        # Change the function
+        def new_a():
+            return 999
+
+        a.func = new_a
+        new_hashes = _collect_hashes([a])
+
+        changed = _diff_hashes(old_hashes, new_hashes)
+        assert changed == ["a"]
+
+    def test_unchanged_function_not_detected(self) -> None:
+        @cell
+        def a():
+            return 1
+
+        @cell(depends_on=[a])
+        def b(a):
+            return a + 1
+
+        old_hashes = _collect_hashes([a, b])
+
+        # Change only b
+        def new_b(a):
+            return a + 100
+
+        b.func = new_b
+        new_hashes = _collect_hashes([a, b])
+
+        changed = _diff_hashes(old_hashes, new_hashes)
+        assert changed == ["b"]
+        assert "a" not in changed
+
+    def test_new_cell_detected(self) -> None:
+        old_hashes = {"a": "hash1"}
+        new_hashes = {"a": "hash1", "b": "hash2"}
+        changed = _diff_hashes(old_hashes, new_hashes)
+        assert changed == ["b"]
+
+
+class TestWatcherReloadAndDiff:
+    def test_reload_detects_change(self, tmp_path: Path) -> None:
+        pipeline_file = tmp_path / "pipeline.py"
+        pipeline_file.write_text(textwrap.dedent("""\
+            from dag.cell import cell
+
+            @cell
+            def a():
+                return 1
+
+            @cell(depends_on=[a])
+            def b(a):
+                return a + 1
+
+            CELLS = [a, b]
+        """))
+
+        watcher = PipelineWatcher(str(pipeline_file))
+        from dag.loader import load_pipeline
+
+        watcher._cells = load_pipeline(str(pipeline_file))
+        watcher._hashes = _collect_hashes(watcher._cells)
+
+        # Modify cell a's function body
+        pipeline_file.write_text(textwrap.dedent("""\
+            from dag.cell import cell
+
+            @cell
+            def a():
+                return 999
+
+            @cell(depends_on=[a])
+            def b(a):
+                return a + 1
+
+            CELLS = [a, b]
+        """))
+
+        changed = watcher._reload_and_diff()
+        assert changed is not None
+        assert "a" in changed
+        assert "b" not in changed
+
+    def test_reload_no_change_returns_none(self, tmp_path: Path) -> None:
+        pipeline_file = tmp_path / "pipeline.py"
+        pipeline_file.write_text(textwrap.dedent("""\
+            from dag.cell import cell
+
+            @cell
+            def a():
+                return 1
+
+            CELLS = [a]
+        """))
+
+        watcher = PipelineWatcher(str(pipeline_file))
+        from dag.loader import load_pipeline
+
+        watcher._cells = load_pipeline(str(pipeline_file))
+        watcher._hashes = _collect_hashes(watcher._cells)
+
+        # Reload without changes
+        changed = watcher._reload_and_diff()
+        assert changed is None
+
+
+class TestSurgicalInvalidation:
+    def test_surgical_run_only_reruns_changed_and_descendants(
+        self, tmp_path: Path
+    ) -> None:
+        """Changed cell + descendants re-run; upstream stays cached."""
+        from dag.engine import PipelineEngine
+        from dag.store import CellStore
+
+        @cell
+        def a():
+            return [1, 2, 3]
+
+        @cell(depends_on=[a])
+        def b(a):
+            return [x for x in a if x > 1]
+
+        @cell(depends_on=[b])
+        def c(b):
+            return len(b)
+
+        cells = [a, b, c]
+        store = CellStore(tmp_path / "cache")
+
+        # Initial run — all execute
+        engine = PipelineEngine(cells, store=store)
+        engine.run_all()
+        assert all(cell.status == "done" for cell in cells)
+        a_last_run = a.last_run
+
+        # Simulate watch: b changed, surgical invalidation
+        store.invalidate(b)
+        store.invalidate(c)  # descendant of b
+
+        # Fresh engine, run_all loads cache for a, re-runs b and c
+        for cell_ in cells:
+            cell_.output = None
+            cell_.status = "pending"
+            cell_.last_run = None
+
+        engine2 = PipelineEngine(cells, store=store)
+        engine2.run_all()
+
+        # a should be cached
+        assert "a" in engine2.cached_cells
+        assert a.last_run is None  # not re-executed
+
+        # b and c should have re-executed
+        assert "b" not in engine2.cached_cells
+        assert "c" not in engine2.cached_cells
+        assert b.last_run is not None
+        assert c.last_run is not None


### PR DESCRIPTION
## Summary
The killer feature: `dag watch examples/p3_analysis.py` turns your terminal into a live-updating reactive dashboard. Edit a cell in your editor, save, and only the changed cells + their descendants re-execute within milliseconds. Unchanged upstream cells stay cached.

**How it works:**
- Polls file mtime (zero extra deps, no watchdog needed)
- On change: re-imports the pipeline, diffs bytecode hashes **per cell** (not file-level)
- Surgically invalidates only changed cells + `nx.descendants()`
- Re-executes the stale subgraph while upstream loads from cache
- Persistent Rich Live table with change summary in caption

**New files:**
- `dag/watcher.py` — `PipelineWatcher` class with poll loop, bytecode diffing, surgical invalidation
- `tests/test_watcher.py` — 7 tests covering hash diffing, reload detection, and surgical re-execution

## Test plan
- [x] Identical hashes produce no changes
- [x] Changed function bytecode detected, unchanged functions ignored
- [x] New cells detected as changes
- [x] File reload detects only the modified cell
- [x] No-change reload returns None (no re-execution)
- [x] Surgical invalidation: upstream cached, changed + descendants re-run
- [x] `dag watch` appears in CLI help
- [x] All 43 tests pass (7 new + 36 existing)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)